### PR TITLE
Fix 'Discontiguous selection is not supported' Error, fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Based on [copy-to-clipboard](https://www.npmjs.com/package/copy-to-clipboard)
 > Would try to use execCommand with fallback to IE specific clipboardData interface and finally, fallback to simple prompt with proper text content & 'Copy to clipboard: Ctrl+C, Enter'
 
 
-![Copy to clipboard](src/example/copy-to-clipboard.gif)
+![Copy to clipboard](https://cdn.rawgit.com/nkbt/react-copy-to-clipboard/master/src/example/copy-to-clipboard.gif)
 
 
 ## Installation
@@ -35,30 +35,23 @@ bower install --save react-copy-to-clipboard
 import React from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
-
 const App = React.createClass({
   getInitialState() {
     return {value: '', copied: false};
   },
 
-
   render() {
     return (
       <div>
-
         <input value={this.state.value}
           onChange={({target: {value}}) => this.setState({value, copied: false})} />&nbsp;
 
         <CopyToClipboard text={this.state.value}
           onCopy={() => this.setState({copied: true})}>
-          <button>Copy to clibpoard</button>
+          Copy to clipboard
         </CopyToClipboard>&nbsp;
 
-
         {this.state.copied ? <span style={{color: 'red'}}>Copied.</span> : null}
-        
-        
-
       </div>
     );
   }
@@ -81,13 +74,13 @@ Text to be copied to clipboard
 Optional callback, will be called when text is copied
 
 
-#### `children`: React.PropTypes.node.isRequired
+#### `children`
 
-CopyToClipboard is a simple wrapping component, it does not render any tags, so it requires one child element to be present, which will be used to capture clicks.
+CopyToClipboard renders `<button>` element, so you can add some inline elements into it (like `<span>` or just text).
 
 ```js
 <CopyToClipboard text="Hello!">
-  <button>Copy to clipboard</button>
+  <span>Copy to clipboard</span>
 </CopyToClipboard>
 ```
 
@@ -119,8 +112,15 @@ open http://localhost:8080
 
 ## Tests
 
-Only UI tests for now, see [demo](http://nkbt.github.io/react-copy-to-clipboard/example)
+```bash
+npm test
 
+# to run tests in watch mode for development
+npm run test:dev
+
+# to generate test coverage (./reports/coverage)
+npm run test:cov
+```
 
 ## License
 

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -9,6 +9,8 @@
 
   "plugins": ["react"],
 
+  "parser": "babel-eslint",
+
   "ecmaFeatures": {
     "arrowFunctions": true,
     "binaryLiterals": true,

--- a/src/CopyToClipboard.js
+++ b/src/CopyToClipboard.js
@@ -2,24 +2,26 @@ import React from 'react';
 import copy from 'copy-to-clipboard';
 
 
+const onClick = (text, onCopy) => () => {
+  copy(text);
+  if (onCopy) {
+    onCopy(text);
+  }
+};
+
+
 const CopyToClipboard = React.createClass({
   propTypes: {
     text: React.PropTypes.string.isRequired,
-    children: React.PropTypes.node.isRequired,
+    children: React.PropTypes.node,
     onCopy: React.PropTypes.func
   },
 
 
-  onClick() {
-    copy(this.props.text);
-    if (this.props.onCopy) {
-      this.props.onCopy(this.props.text);
-    }
-  },
-
-
   render() {
-    return React.cloneElement(React.Children.only(this.props.children), {onClick: this.onClick});
+    const {text, onCopy, ...props} = this.props;
+
+    return <button {...props} onClick={onClick(text, onCopy)} />;
   }
 });
 

--- a/src/CopyToClipboard.js
+++ b/src/CopyToClipboard.js
@@ -13,7 +13,6 @@ const onClick = (text, onCopy) => () => {
 const CopyToClipboard = React.createClass({
   propTypes: {
     text: React.PropTypes.string.isRequired,
-    children: React.PropTypes.node,
     onCopy: React.PropTypes.func
   },
 
@@ -21,7 +20,7 @@ const CopyToClipboard = React.createClass({
   render() {
     const {text, onCopy, ...props} = this.props;
 
-    return <button {...props} onClick={onClick(text, onCopy)} />;
+    return <button onClick={onClick(text, onCopy)} {...props} />;
   }
 });
 

--- a/src/example/Example.js
+++ b/src/example/Example.js
@@ -18,14 +18,15 @@ const App = React.createClass({
 
         <CopyToClipboard text={this.state.value}
           onCopy={() => this.setState({copied: true})}>
-          <button>Copy to clipboard</button>
+          <span>Copy to clipboard</span>
         </CopyToClipboard>&nbsp;
 
 
         {this.state.copied ? <span style={{color: 'red'}}>Copied.</span> : null}
 
         <br />
-        <textarea style={{marginTop: '1em'}} cols="22" rows="3"></textarea>
+
+        <textarea style={{marginTop: '1em'}} cols="22" rows="3" />
 
       </div>
     );

--- a/test/CopyToClipboard-test.js
+++ b/test/CopyToClipboard-test.js
@@ -31,8 +31,18 @@ describe('CopyToClipboard', () => {
   });
 
 
-  it('should require a single child to be present', () => {
-    expect(create).toThrow();
+  it('should not require children to be present', () => {
+    expect(create).not.toThrow();
+  });
+
+
+  it('should be ok with multiple children present', () => {
+    expect(() => TestUtils.renderIntoDocument((
+      <CopyToClipboard text="test" onCopy={onCopy}>
+        <span>one</span>
+        <span>two</span>
+      </CopyToClipboard>
+    ))).not.toThrow();
   });
 
 
@@ -68,5 +78,20 @@ describe('CopyToClipboard', () => {
       .renderIntoDocument(<CopyToClipboard text="ok"><span>test</span></CopyToClipboard>));
 
     expect(TestUtils.Simulate.click.bind(null, span)).not.toThrow();
+  });
+
+
+  it('should pass props to the rendered button', () => {
+    const button = TestUtils.renderIntoDocument((
+      <CopyToClipboard
+        text="hello" onCopy={onCopy}
+        className="testClass" style={{display: 'none'}}>
+        <span>test</span>
+      </CopyToClipboard>
+    ));
+    const buttonElement = React.findDOMNode(button);
+
+    expect(buttonElement.className).toEqual('testClass');
+    expect(buttonElement.style.display).toEqual('none');
   });
 });


### PR DESCRIPTION
@moroshko I've done some breaking changes to see if it all works (#5). And it actually does. But I am not sure if going from wrapper-component to component that renders something is a very good idea.

Maybe it is better to simply validate if child is `button` so it must be a `button`?