### PR TITLE
Optional child

### DIFF
--- a/src/CopyToClipboard.js
+++ b/src/CopyToClipboard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import copy from 'copy-to-clipboard';
 
-
 const onClick = (text, onCopy) => () => {
   copy(text);
   if (onCopy) {
@@ -9,18 +8,21 @@ const onClick = (text, onCopy) => () => {
   }
 };
 
-
 const CopyToClipboard = React.createClass({
   propTypes: {
     text: React.PropTypes.string.isRequired,
-    onCopy: React.PropTypes.func
+    onCopy: React.PropTypes.func,
+    children: React.PropTypes.array
   },
 
 
   render() {
-    const {text, onCopy, ...props} = this.props;
+    const {text, onCopy, children, ...props} = this.props;
+    const elem = React.Children.only(children);
 
-    return <button onClick={onClick(text, onCopy)} {...props} />;
+    return React.cloneElement(elem, Object.assign({
+      onClick: onClick(text, onCopy)
+    }, props));
   }
 });
 

--- a/src/example/Example.js
+++ b/src/example/Example.js
@@ -14,12 +14,12 @@ const App = React.createClass({
           size={10}
           onChange={({target: {value}}) => this.setState({value, copied: false})} />&nbsp;
 
-        <CopyToClipboard text={this.state.value} className="text-blue"
+        <CopyToClipboard text={this.state.value}
           onCopy={() => this.setState({copied: true})}>
           <span>Copy to clipboard with span</span>
         </CopyToClipboard>&nbsp;
 
-        <CopyToClipboard text={this.state.value} className="text-blue"
+        <CopyToClipboard text={this.state.value}
           onCopy={() => this.setState({copied: true})}>
           <button>Copy to clipboard with button</button>
         </CopyToClipboard>&nbsp;

--- a/src/example/Example.js
+++ b/src/example/Example.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import CopyToClipboard from '..';
 
-
 const App = React.createClass({
   getInitialState() {
     return {value: '', copied: false};
@@ -11,14 +10,18 @@ const App = React.createClass({
   render() {
     return (
       <div>
-
         <input value={this.state.value}
           size={10}
           onChange={({target: {value}}) => this.setState({value, copied: false})} />&nbsp;
 
-        <CopyToClipboard text={this.state.value}
+        <CopyToClipboard text={this.state.value} className="text-blue"
           onCopy={() => this.setState({copied: true})}>
-          <span>Copy to clipboard</span>
+          <span>Copy to clipboard with span</span>
+        </CopyToClipboard>&nbsp;
+
+        <CopyToClipboard text={this.state.value} className="text-blue"
+          onCopy={() => this.setState({copied: true})}>
+          <button>Copy to clipboard with button</button>
         </CopyToClipboard>&nbsp;
 
 
@@ -32,6 +35,5 @@ const App = React.createClass({
     );
   }
 });
-
 
 React.render(<App />, document.body);

--- a/test/CopyToClipboard-test.js
+++ b/test/CopyToClipboard-test.js
@@ -31,8 +31,8 @@ describe('CopyToClipboard', () => {
   });
 
 
-  it('should not require children to be present', () => {
-    expect(create).not.toThrow();
+  it('should require children to be present', () => {
+    expect(create).toThrow();
   });
 
 
@@ -42,9 +42,16 @@ describe('CopyToClipboard', () => {
         <span>one</span>
         <span>two</span>
       </CopyToClipboard>
-    ))).not.toThrow();
+    ))).toThrow();
   });
 
+  it('should be expect one child present', () => {
+    expect(() => TestUtils.renderIntoDocument((
+      <CopyToClipboard text="test" onCopy={onCopy}>
+        <span>one</span>
+      </CopyToClipboard>
+    ))).not.toThrow();
+  });
 
   it('should copy on click on child element', () => {
     const span = React.findDOMNode(create(<span>test</span>));
@@ -86,12 +93,13 @@ describe('CopyToClipboard', () => {
       <CopyToClipboard
         text="hello" onCopy={onCopy}
         className="testClass" style={{display: 'none'}}>
-        <span>test</span>
+        <button>test</button>
       </CopyToClipboard>
     ));
     const buttonElement = React.findDOMNode(button);
 
     expect(buttonElement.className).toEqual('testClass');
     expect(buttonElement.style.display).toEqual('none');
+    expect(buttonElement.nodeName.toLowerCase()).toEqual('button');
   });
 });


### PR DESCRIPTION
Rather than having only a button, now react-copy-to-chipboard will use the child and attach the props to it. So you can have any element trigger copying