### PR TITLE
Bypass onClick if passed from outside as prop without override

### DIFF
--- a/src/CopyToClipboard.js
+++ b/src/CopyToClipboard.js
@@ -1,29 +1,42 @@
 import React from 'react';
 import copy from 'copy-to-clipboard';
 
-const onClick = (text, onCopy) => () => {
-  copy(text);
-  if (onCopy) {
-    onCopy(text);
-  }
-};
 
 const CopyToClipboard = React.createClass({
   propTypes: {
     text: React.PropTypes.string.isRequired,
     children: React.PropTypes.element.isRequired,
+    onClick: React.PropTypes.func,
     onCopy: React.PropTypes.func
   },
 
 
+  onClick(e) {
+    const {text, onCopy, onClick} = this.props;
+
+    copy(text);
+    if (onCopy) {
+      onCopy(text);
+    }
+
+    // Bypass onClick if it was present
+    if (onClick) {
+      onClick(e);
+    }
+  },
+
+
   render() {
-    const {text, onCopy, children, ...props} = this.props;
+    const {
+      text: _text,
+      onCopy: _onCopy,
+      onClick: _onClick,
+      children,
+      ...props
+    } = this.props;
     const elem = React.Children.only(children);
 
-    return React.cloneElement(elem, {
-      ...props,
-      onClick: onClick(text, onCopy)
-    });
+    return React.cloneElement(elem, {...props, onClick: this.onClick});
   }
 });
 

--- a/src/CopyToClipboard.js
+++ b/src/CopyToClipboard.js
@@ -6,13 +6,13 @@ const CopyToClipboard = React.createClass({
   propTypes: {
     text: React.PropTypes.string.isRequired,
     children: React.PropTypes.element.isRequired,
-    onClick: React.PropTypes.func,
     onCopy: React.PropTypes.func
   },
 
 
-  onClick(e) {
-    const {text, onCopy, onClick} = this.props;
+  onClick(event) {
+    const {text, onCopy, children} = this.props;
+    const elem = React.Children.only(children);
 
     copy(text);
     if (onCopy) {
@@ -20,8 +20,8 @@ const CopyToClipboard = React.createClass({
     }
 
     // Bypass onClick if it was present
-    if (onClick) {
-      onClick(e);
+    if (elem && elem.props && typeof elem.props.onClick === 'function') {
+      elem.props.onClick(event);
     }
   },
 
@@ -30,7 +30,6 @@ const CopyToClipboard = React.createClass({
     const {
       text: _text,
       onCopy: _onCopy,
-      onClick: _onClick,
       children,
       ...props
     } = this.props;

--- a/src/example/App/index.js
+++ b/src/example/App/index.js
@@ -20,6 +20,11 @@ const App = React.createClass({
   },
 
 
+  onClick({target: {innerHTML}}) {
+    console.log(`Clicked on "${innerHTML}"!`); // eslint-disable-line
+  },
+
+
   render() {
     return (
       <div className={css.app}>
@@ -33,6 +38,10 @@ const App = React.createClass({
 
         <CopyToClipboard text={this.state.value} onCopy={this.onCopy}>
           <button>Copy to clipboard with button</button>
+        </CopyToClipboard>&nbsp;
+
+        <CopyToClipboard text={this.state.value} onCopy={this.onCopy}>
+          <button onClick={this.onClick}>Copy to clipboard with onClick prop</button>
         </CopyToClipboard>&nbsp;
 
 


### PR DESCRIPTION
Fixes #25 
Fixes #23 

Also some perf improvement by not re-creating `onClick` callback on each render