### PR TITLE
Add didCopy value from copy-to-clipboard to onCopy callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Text to be copied to clipboard
 
 #### `onCopy`: React.PropTypes.func
 
-Optional callback, will be called when text is copied
+Optional callback, will be called when text is copied.
+`callback(text:string, didCopy: boolean)`. where `text` is the text that was passed in and `didCopy` is the result value of copy-to-clipboard: `true` if no additional keystrokes were required from user (so, `execCommand`, IE's `clipboardData` worked) or `false`.
 
 
 #### `options`: React.PropTypes.shape({debug: bool, message: string})

--- a/src/Component.js
+++ b/src/Component.js
@@ -18,9 +18,9 @@ export const CopyToClipboard = React.createClass({
     const {text, onCopy, children, options} = this.props;
     const elem = React.Children.only(children);
 
-    copy(text, options);
+    const didCopy = copy(text, options);
     if (onCopy) {
-      onCopy(text);
+      onCopy(text, didCopy);
     }
 
     // Bypass onClick if it was present


### PR DESCRIPTION
Right now even if the user hits cancel or has to manually copy, it returns onCopy(text), meaning I'm displaying a "Copied to clipboard!" toast even if the user didn't copy it to the clipboard. 
