### PR TITLE
remove nbsp from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,17 @@ const App = React.createClass({
     return (
       <div>
         <input value={this.state.value}
-          onChange={({target: {value}}) => this.setState({value, copied: false})} />&nbsp;
+          onChange={({target: {value}}) => this.setState({value, copied: false})} />
 
         <CopyToClipboard text={this.state.value}
           onCopy={() => this.setState({copied: true})}>
           <span>Copy to clipboard with span</span>
-        </CopyToClipboard>&nbsp;
+        </CopyToClipboard>
 
         <CopyToClipboard text={this.state.value}
           onCopy={() => this.setState({copied: true})}>
           <button>Copy to clipboard with button</button>
-        </CopyToClipboard>&nbsp;
+        </CopyToClipboard>
 
         {this.state.copied ? <span style={{color: 'red'}}>Copied.</span> : null}
       </div>


### PR DESCRIPTION
`nbsp` is needed in the codepen, but not in the Readme. From a readability stand point its better without them.