### PR TITLE
Make compatible with preact

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -22,8 +22,6 @@ export class CopyToClipboard extends React.PureComponent {
       options
     } = this.props;
 
-    const elem = React.Children.only(children);
-
     const result = copy(text, options);
 
     if (onCopy) {
@@ -31,8 +29,8 @@ export class CopyToClipboard extends React.PureComponent {
     }
 
     // Bypass onClick if it was present
-    if (elem && elem.props && typeof elem.props.onClick === 'function') {
-      elem.props.onClick(event);
+    if (children && children.props && typeof children.props.onClick === 'function') {
+      children.props.onClick(event);
     }
   };
 
@@ -41,11 +39,11 @@ export class CopyToClipboard extends React.PureComponent {
       text: _text,
       onCopy: _onCopy,
       options: _options,
+      onClickCapture,  // eslint-disable-line
       children,
       ...props
     } = this.props;
-    const elem = React.Children.only(children);
 
-    return React.cloneElement(elem, {...props, onClick: this.onClick});
+    return React.cloneElement(children, {...props, onClick: this.onClick});
   }
 }

--- a/src/Component.js
+++ b/src/Component.js
@@ -41,9 +41,9 @@ export class CopyToClipboard extends React.PureComponent {
       options: _options,
       onClickCapture,  // eslint-disable-line
       children,
-      ...props
+      ...restProps
     } = this.props;
 
-    return React.cloneElement(children, {...props, onClick: this.onClick});
+    return React.cloneElement(children, {...restProps, onClick: this.onClick});
   }
 }

--- a/src/Component.js
+++ b/src/Component.js
@@ -6,6 +6,7 @@ import copy from 'copy-to-clipboard';
 export class CopyToClipboard extends React.PureComponent {
   static propTypes = {
     text: PropTypes.string.isRequired,
+    onClickCapture: PropTypes.func,
     children: PropTypes.element.isRequired,
     onCopy: PropTypes.func,
     options: PropTypes.shape({
@@ -39,7 +40,7 @@ export class CopyToClipboard extends React.PureComponent {
       text: _text,
       onCopy: _onCopy,
       options: _options,
-      onClickCapture,  // eslint-disable-line
+      onClickCapture: _onClickCapture,
       children,
       ...restProps
     } = this.props;


### PR DESCRIPTION
* Don't use `React.Children`
* Extract `onClickCapture` since preact doesn't support Synthetic Events

For more info, see:
https://github.com/developit/preact/wiki/Differences-to-React#whats-missing

It would be nice to merge this in unless you see issues with it, but I figured at least I'll point out how we fixed it! :)