### PR TITLE
updating readme to use React.component instead of createClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ then include as
 ```js
 import React from 'react';
 import ReactDOM from 'react-dom';
-import createReactClass from 'create-react-class';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
-const App = createReactClass({
-  getInitialState() {
-    return {value: '', copied: false};
-  },
+class App extends React.Component {
+  state = {
+    value: '',
+    copied: false,
+  }
 
   render() {
     return (
@@ -99,7 +99,7 @@ const App = createReactClass({
       </div>
     );
   }
-});
+}
 
 const appRoot = document.createElement('div');
 document.body.appendChild(appRoot);


### PR DESCRIPTION
since the underlying code of the component is using `es6` classes(https://github.com/nkbt/react-copy-to-clipboard/commit/f70e377b99106faff1f648f38a713208cb85fe23), it makes sense for the Readme to also reflect the same.

