### PR TITLE
Copied text transformer 

### DIFF
--- a/example/App/index.js
+++ b/example/App/index.js
@@ -17,7 +17,7 @@ export class App extends React.PureComponent {
     this.setState({copied: true});
   };
 
-  transform = (text) => `"${text.trim()}"`;
+  transform = text => `"${text.trim()}"`;
 
   render() {
     return (
@@ -37,7 +37,9 @@ export class App extends React.PureComponent {
 
         <section className="section">
           <h2>2. Button with transformer</h2>
-          <CopyToClipboard onCopy={this.onCopy} text={this.state.value} transformer={this.transform}>
+          <CopyToClipboard onCopy={this.onCopy} 
+                           text={this.state.value} 
+                           transformer={this.transform}>
             <button>Copy to clipboard with button</button>
           </CopyToClipboard>
         </section>

--- a/example/App/index.js
+++ b/example/App/index.js
@@ -17,6 +17,8 @@ export class App extends React.PureComponent {
     this.setState({copied: true});
   };
 
+  transform = (text) => `"${text.trim()}"`;
+
   render() {
     return (
       <div className="app">
@@ -29,6 +31,13 @@ export class App extends React.PureComponent {
         <section className="section">
           <h2>1. Button</h2>
           <CopyToClipboard onCopy={this.onCopy} text={this.state.value}>
+            <button>Copy to clipboard with button</button>
+          </CopyToClipboard>
+        </section>
+
+        <section className="section">
+          <h2>2. Button with transformer</h2>
+          <CopyToClipboard onCopy={this.onCopy} text={this.state.value} transformer={this.transform}>
             <button>Copy to clipboard with button</button>
           </CopyToClipboard>
         </section>

--- a/src/Component.js
+++ b/src/Component.js
@@ -19,7 +19,7 @@ export class CopyToClipboard extends React.PureComponent {
   static defaultProps = {
     onCopy: undefined,
     options: undefined,
-    transformer: (text) => text
+    transformer: text => text
   };
 
 

--- a/src/Component.js
+++ b/src/Component.js
@@ -52,6 +52,7 @@ export class CopyToClipboard extends React.PureComponent {
       text: _text,
       onCopy: _onCopy,
       options: _options,
+      transformer: _transformer,
       children,
       ...props
     } = this.props;

--- a/src/Component.js
+++ b/src/Component.js
@@ -8,6 +8,7 @@ export class CopyToClipboard extends React.PureComponent {
     text: PropTypes.string.isRequired,
     children: PropTypes.element.isRequired,
     onCopy: PropTypes.func,
+    transformer: PropTypes.func,
     options: PropTypes.shape({
       debug: PropTypes.bool,
       message: PropTypes.string
@@ -17,7 +18,8 @@ export class CopyToClipboard extends React.PureComponent {
 
   static defaultProps = {
     onCopy: undefined,
-    options: undefined
+    options: undefined,
+    transformer: (text) => text
   };
 
 
@@ -25,16 +27,17 @@ export class CopyToClipboard extends React.PureComponent {
     const {
       text,
       onCopy,
+      transformer,
       children,
       options
     } = this.props;
 
     const elem = React.Children.only(children);
-
-    const result = copy(text, options);
+    const transformedText = transformer(text);
+    const result = copy(transformedText, options);
 
     if (onCopy) {
-      onCopy(text, result);
+      onCopy(transformedText, result);
     }
 
     // Bypass onClick if it was present


### PR DESCRIPTION
The transformer is an optional prop, that modifies the content before it is copied to the clipboard.

Examples of uses:
- clearing markdown
- adding quotes
- trimming spaces
- changing line break symbols