### PR TITLE
Use Component instead of PureComponent

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import copy from 'copy-to-clipboard';
 
 
-export class CopyToClipboard extends React.PureComponent {
+export class CopyToClipboard extends React.Component {
   static propTypes = {
     text: PropTypes.string.isRequired,
     children: PropTypes.element.isRequired,


### PR DESCRIPTION
In this case, since `children` is required, `React.createElement` will return new objects for children each render, always negating the pure check. This leads to excess overhead (albeit minuscule) of checking props equality before re-rendering. Switching to a regular component omits this overhead.