### PR TITLE
Change example code to use default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Don't forget to manually install peer dependencies (`react`) if you use npm@3.
 ```js
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {CopyToClipboard} from 'react-copy-to-clipboard';
+import CopyToClipboard from 'react-copy-to-clipboard';
 
 class App extends React.Component {
   state = {


### PR DESCRIPTION
Hi there. I just installed this library in a `create-react-app`/`typescript` project, and was unable to import the component with the current example code. By changing to a default export, however, it worked.

Here's the code that worked:
```
import React from "react";

import styles from "./SetupPage.module.css";
import CopyToClipboard from "react-copy-to-clipboard";

export const CodeBlock = ({ text }: { text: string }) => {
  return (
    <>
      <div>
        <CopyToClipboard text="hello">
          <button>hello</button>
        </CopyToClipboard>
      </div>
      <div className={styles.codeBlockWrapper}>
        <div className={styles.codeBlock}>{text}</div>
      </div>
    </>
  );
};

```

I could be wrong with the fix, and if I am, please let me know how to handle it!