### PR TITLE
Add React v17 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "homepage": "https://github.com/nkbt/react-copy-to-clipboard",
   "peerDependencies": {
-    "react": "^15.3.0 || ^16.0.0"
+    "react": "^15.3.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "copy-to-clipboard": "^3",


### PR DESCRIPTION
Can confirm it works with React v17. Will remove the console warnings for those already on React v17.