### PR TITLE
Add hook 'useClipboard' for use on reusable component and easily to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,30 @@ CopyToClipboard is a simple wrapping component, it does not render any tags, so 
 </CopyToClipboard>
 ```
 
+## Hooks
+### useClipboard
+```js
+import {useClipboard} from 'react-copy-to-clipboard';
+
+const CopyButton = () => {
+  const [isCopy, setClipboard] = useClipboard()
+  const onClickButton = () => {
+    setClipboard('Copy Text Example')
+  }
+
+  return (
+    <div>
+      {isCopy && <span>Copied!</span>}
+      <button onClick={onClickButton}>Submit</button>
+    </div>
+  )
+}
+
+```
+#### `setClipboard`: PropTypes.func
+#### `isCopy`: PropTypes.booleen
+
+
 ## Development and testing
 
 Currently is being developed and tested with the latest stable `Node 8` on `OSX`.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint .",
     "prepub": "rm -rf ./pub",
     "pub": "NODE_ENV=production webpack-cli --config ./webpack/pub.config.js",
-    "test": "node test/Component-test.js",
+    "test": "node test/Component-test.js && node test/Hook-test.js",
     "prepublishOnly": "yarn build",
     "postversion": "git push --follow-tags",
     "deps": "depcheck",

--- a/src/Hook.js
+++ b/src/Hook.js
@@ -1,0 +1,20 @@
+import {useState} from 'react';
+import copy from 'copy-to-clipboard';
+
+export const useClipboard = () => {
+  const [isCopy, setIsCopy] = useState(false);
+
+  const setClipboard = (text, options) => {
+    const result = copy(text, options);
+    setIsCopy(true);
+    return {
+      result,
+      isCopy
+    };
+  };
+
+  return [
+    isCopy,
+    setClipboard
+  ];
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
-
 const {CopyToClipboard} = require('./Component');
+const {useClipboard} = require('./Hook');
 
+const ClipboardModules = {
+  CopyToClipboard,
+  useClipboard
+};
 
-CopyToClipboard.CopyToClipboard = CopyToClipboard;
-module.exports = CopyToClipboard;
+module.exports = ClipboardModules;

--- a/test/Component-test.js
+++ b/test/Component-test.js
@@ -21,7 +21,7 @@ babel({
 });
 
 const test = require('tape');
-const {CopyToClipboard} = require('../src/Component');
+const {CopyToClipboard} = require('../src');
 
 test('CopyToClipboard', t => {
   t.ok(CopyToClipboard instanceof Function, 'should be function');

--- a/test/Hook-test.js
+++ b/test/Hook-test.js
@@ -1,0 +1,29 @@
+const babel = require('@babel/register');
+
+babel({
+  babelrc: false,
+  plugins: [
+    require.resolve('@babel/plugin-proposal-object-rest-spread'),
+    require.resolve('@babel/plugin-proposal-class-properties')
+  ],
+  presets: [
+    require.resolve('@babel/preset-react'),
+    [require.resolve('@babel/preset-env'), {
+      targets: {
+        node: '10'
+      },
+      modules: 'commonjs',
+      loose: true
+    }]
+  ],
+  retainLines: true,
+  comments: false
+});
+
+const test = require('tape');
+const {useClipboard} = require('../src');
+
+test('useClipboard', t => {
+  t.ok(useClipboard instanceof Function, 'should be function');
+  t.end();
+});


### PR DESCRIPTION
```
import {useClipboard} from 'react-copy-to-clipboard';

const CopyButton = () => {
  const [isCopy, setClipboard] = useClipboard()
  const onClickButton = () => {
    setClipboard('Copy Text Example')
  }

  return (
    <div>
      {isCopy && <span>Copied!</span>}
      <button onClick={onClickButton}>Submit</button>
    </div>
  )
}
```

setClipboard: PropTypes.func
isCopy: PropTypes.booleen
