### PR TITLE
Add Type for Typescript Project

### DIFF
--- a/types/CopyToClipboardTypes.ts
+++ b/types/CopyToClipboardTypes.ts
@@ -1,0 +1,25 @@
+import * as React from 'react';
+
+export as namespace CopyToClipboard;
+
+declare class CopyToClipboard extends React.PureComponent<CopyToClipboard.Props> {}
+
+declare namespace CopyToClipboard {
+    class CopyToClipboard extends React.PureComponent<Props> {}
+
+    interface Options {
+        debug?: boolean | undefined;
+        message?: string | undefined;
+        format?: string | undefined; // MIME type
+    }
+
+    interface Props {
+        children?: React.ReactChild;
+        text: string;
+        onCopy?(text: string, result: boolean): void;
+        options?: Options | undefined;
+    }
+}
+
+export = CopyToClipboard;
+


### PR DESCRIPTION
How to use it ?
modified ```tsconfig.json```

```
{
  "typeRoots": [
    "node_modules/react-copy-to-clipboard/types/CopyToClipboardTypes.ts"
  ]
}
```

