### PR TITLE
Add click event to onCopy

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -35,7 +35,7 @@ export class CopyToClipboard extends React.PureComponent {
     const result = copy(text, options);
 
     if (onCopy) {
-      onCopy(text, result);
+      onCopy(text, result, event);
     }
 
     // Bypass onClick if it was present

--- a/test/Component-test.js
+++ b/test/Component-test.js
@@ -129,5 +129,18 @@ describe('CopyToClipboard', () => {
     expect(buttonElement.style.display).toEqual('none');
     expect(buttonElement.nodeName.toLowerCase()).toEqual('button');
   });
+
+  it('should pass event in onCopy', () => {
+    let hasEvent = false;
+    const handleOnCopy = (_, __, event) => hasEvent = !!event
+    const button = TestUtils.renderIntoDocument((
+      <CopyToClipboard onCopy={handleOnCopy}>
+        <button>test event</button>
+      </CopyToClipboard>
+    ));
+    const buttonElement = React.findDOMNode(button);
+    TestUtils.Simulate.click(buttonElement);
+    expect(hasEvent).toEqual(true);
+  });
 });
- */
+*/


### PR DESCRIPTION
Return the mouse event as a third parameter in the `onCopy` method. The particular use case is to allow event interception and stop propagation where needed. This avoids having to wrap the parent in an element with an `onClick` which violates a11y principles of only having click behavior on interactive elements.

Corresponding pull request for type defs:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64963